### PR TITLE
Extract error information from JSON.

### DIFF
--- a/bindings/osrm_c89.c
+++ b/bindings/osrm_c89.c
@@ -84,7 +84,7 @@ config_cleanup:
 
   /* If we got here on a failure path notify the user */
   if (error) {
-    fprintf(stderr, "Error: %s\n", osrmc_error_message(error));
+    fprintf(stderr, "Error: code=%s, message=%s\n", osrmc_error_code(error), osrmc_error_message(error));
     osrmc_error_destruct(error);
     return EXIT_FAILURE;
   }

--- a/libosrmc/osrmc.h
+++ b/libosrmc/osrmc.h
@@ -159,6 +159,7 @@ typedef void (*osrmc_waypoint_handler_t)(void* data, const char* name, float lon
 
 /* Error handling */
 
+OSRMC_API const char* osrmc_error_code(osrmc_error_t error);
 OSRMC_API const char* osrmc_error_message(osrmc_error_t error);
 OSRMC_API void osrmc_error_destruct(osrmc_error_t error);
 


### PR DESCRIPTION
When OSRM returns an error, it (often?) includes an error code/message in the returned JSON object. This change extracts this code/message and returns it to the caller of libosrmc.

This makes it easier to debug failures, but also makes it possible to react to errors such as `NoRoute`. An example of such a route is between `25.07165,55.402115` and `25.086226,55.385334` in the UAE, using the `foot` or `bicycle` profiles. 