### PR TITLE
Add support for Duration & Distance in Table API.

### DIFF
--- a/bindings/osrm_c89.c
+++ b/bindings/osrm_c89.c
@@ -84,7 +84,7 @@ config_cleanup:
 
   /* If we got here on a failure path notify the user */
   if (error) {
-    fprintf(stderr, "Error: %s\n", osrmc_error_message(error));
+    fprintf(stderr, "Error: code=%s, message=%s\n", osrmc_error_code(error), osrmc_error_message(error));
     osrmc_error_destruct(error);
     return EXIT_FAILURE;
   }

--- a/libosrmc/osrmc.h
+++ b/libosrmc/osrmc.h
@@ -159,6 +159,7 @@ typedef void (*osrmc_waypoint_handler_t)(void* data, const char* name, float lon
 
 /* Error handling */
 
+OSRMC_API const char* osrmc_error_code(osrmc_error_t error);
 OSRMC_API const char* osrmc_error_message(osrmc_error_t error);
 OSRMC_API void osrmc_error_destruct(osrmc_error_t error);
 

--- a/libosrmc/osrmc.h
+++ b/libosrmc/osrmc.h
@@ -1,3 +1,5 @@
+#include <stdbool.h>
+
 #ifndef OSRMC_H_
 #define OSRMC_H_
 
@@ -144,6 +146,7 @@ typedef struct osrmc_params* osrmc_params_t;
 
 typedef struct osrmc_route_params* osrmc_route_params_t;
 typedef struct osrmc_table_params* osrmc_table_params_t;
+typedef struct osrmc_table_annotations* osrmc_table_annotations_t;
 typedef struct osrmc_nearest_params* osrmc_nearest_params_t;
 typedef struct osrmc_match_params* osrmc_match_params_t;
 
@@ -194,15 +197,26 @@ OSRMC_API float osrmc_route_response_duration(osrmc_route_response_t response, o
 
 /* Table service */
 
+OSRMC_API osrmc_table_annotations_t osrmc_table_annotations_construct(osrmc_error_t* error);
+OSRMC_API void osrmc_table_annotations_destruct(osrmc_table_annotations_t annotations);
+OSRMC_API void osrmc_table_annotations_enable_distance(osrmc_table_annotations_t annotations, bool enable, osrmc_error_t* error);
+
 OSRMC_API osrmc_table_params_t osrmc_table_params_construct(osrmc_error_t* error);
 OSRMC_API void osrmc_table_params_destruct(osrmc_table_params_t params);
+OSRMC_API void osrmc_table_params_set_annotations(osrmc_table_params_t params, osrmc_table_annotations_t annotations, osrmc_error_t* error);
 OSRMC_API void osrmc_table_params_add_source(osrmc_table_params_t params, size_t index, osrmc_error_t* error);
 OSRMC_API void osrmc_table_params_add_destination(osrmc_table_params_t params, size_t index, osrmc_error_t* error);
 
 OSRMC_API osrmc_table_response_t osrmc_table(osrmc_osrm_t osrm, osrmc_table_params_t params, osrmc_error_t* error);
 OSRMC_API void osrmc_table_response_destruct(osrmc_table_response_t response);
+
+// INFINITY will be returned if there is no route between the from/to.
+// An error will also be returned with a code of 'NoRoute'.
 OSRMC_API float osrmc_table_response_duration(osrmc_table_response_t response, unsigned long from, unsigned long to,
                                               osrmc_error_t* error);
+OSRMC_API float osrmc_table_response_distance(osrmc_table_response_t response, unsigned long from, unsigned long to,
+                                              osrmc_error_t* error);
+
 /* Nearest service */
 
 OSRMC_API osrmc_nearest_params_t osrmc_nearest_params_construct(osrmc_error_t* error);


### PR DESCRIPTION
Add the ability to specify whether the table should be annotated with
distance and/or duration, as well as a new API for returning the
distance. This is done in a way that allows us to return errors for
unrouteable routes (where `null` is returned in the JSON), as in #7.

I'm not 100% sure of the use of `stdbool` in a FFI interface - it's been
a while since I had to write C!