### PR TITLE
Complete request and response parsing for Route service

### DIFF
--- a/libosrmc/config.mk
+++ b/libosrmc/config.mk
@@ -3,6 +3,6 @@ PREFIX = /usr/local
 VERSION_MAJOR = 5
 VERSION_MINOR = 4
 
-CXXFLAGS = -O2 -Wall -Wextra -pedantic -std=c++11 -fvisibility=hidden -fPIC -fno-rtti $(shell pkg-config --cflags libosrm)
+CXXFLAGS = -O2 -Wall -Wextra -pedantic -std=c++14 -fvisibility=hidden -fPIC -fno-rtti $(shell pkg-config --cflags libosrm) $(shell pkg-config --cflags python3)
 LDFLAGS  = -shared -Wl,-soname,libosrmc.so.$(VERSION_MAJOR)
 LDLIBS   = -lstdc++ $(shell pkg-config --libs libosrm)

--- a/libosrmc/osrmc.h
+++ b/libosrmc/osrmc.h
@@ -155,6 +155,7 @@ typedef struct osrmc_match_params* osrmc_match_params_t;
 typedef struct osrmc_route_response* osrmc_route_response_t;
 typedef struct osrmc_table_response* osrmc_table_response_t;
 
+typedef struct osrmc_json* osrmc_json_t;
 /* Service-specific callbacks */
 
 typedef void (*osrmc_waypoint_handler_t)(void* data, const char* name, float longitude, float latitude);
@@ -229,6 +230,7 @@ OSRMC_API osrmc_match_params_t osrmc_match_params_construct(osrmc_error_t* error
 OSRMC_API void osrmc_match_params_destruct(osrmc_match_params_t params);
 OSRMC_API void osrmc_match_params_add_timestamp(osrmc_match_params_t params, unsigned timestamp, osrmc_error_t* error);
 
+OSRMC_API PyObject *osrmc_json_to_pyobj(osrmc_json_t obj);
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Modified the osrmc_route in the library to accept a python dictionary object
which eases the usage of the route service from the python binding.

Also added a C++ class to parse the json return value to python dictionary so
that it is easy use in the python binding.

Tested against py2 as well py3